### PR TITLE
Add support for passing multiple URLs as space-separated string.

### DIFF
--- a/lightkeeper.coffee
+++ b/lightkeeper.coffee
@@ -35,8 +35,7 @@ program
 		else ['mobile', 'desktop']
 	blockedUrls = if block then block.split ',' else []
 
-	# If url contains a space, assume space-separated URLs.  Split into array and
-	# test each url.
+	# Support comma delmited URLs or single URls
 	urls = url.split ','
 	for url in urls
 		console.log ""

--- a/lightkeeper.coffee
+++ b/lightkeeper.coffee
@@ -20,7 +20,7 @@ process.on 'SIGINT', -> process.exit(0)
 # Setup CLI
 program
 .description 'Averages multiple successive Lighthouse tests'
-.argument '<url>', 'The URL to test'
+.argument '<url>', 'The comma-delimited URL(s) to test'
 .option '-t, --times <count>', 'The number of tests to run', default: 10
 .option '-d, --desktop', 'Test only desktop'
 .option '-m, --mobile ', 'Test only mobile'
@@ -35,18 +35,15 @@ program
 		else ['mobile', 'desktop']
 	blockedUrls = if block then block.split ',' else []
 
-	if (url?.indexOf?(" ") > 0)
-		# If url contains a space, assume space-separated URLs.  Split into array and test each url.
-		urls = url.split?(" ")
-		for url in urls
-			# Output this site's url
-			console.log ""
-			console.log chalk.green.bold url
-			console.log ""
-			# Test this url
-			await execute { url, times, devices, blockedUrls, summary }
-	else
-		execute { url, times, devices, blockedUrls, summary }
+	# If url contains a space, assume space-separated URLs.  Split into array and
+	# test each url.
+	urls = url.split ','
+	for url in urls
+		console.log ""
+		console.log chalk.yellow.bold url
+		await execute { url, times, devices, blockedUrls, summary }
+
+# Start cli program
 program.run()
 
 # Boot up the runner

--- a/lightkeeper.coffee
+++ b/lightkeeper.coffee
@@ -34,7 +34,19 @@ program
 		when desktop then ['desktop']
 		else ['mobile', 'desktop']
 	blockedUrls = if block then block.split ',' else []
-	execute { url, times, devices, blockedUrls, summary }
+
+	if (url?.indexOf?(" ") > 0)
+		# If url contains a space, assume space-separated URLs.  Split into array and test each url.
+		urls = url.split?(" ")
+		for url in urls
+			# Output this site's url
+			console.log ""
+			console.log chalk.green.bold url
+			console.log ""
+			# Test this url
+			await execute { url, times, devices, blockedUrls, summary }
+	else
+		execute { url, times, devices, blockedUrls, summary }
 program.run()
 
 # Boot up the runner

--- a/lightkeeper.js
+++ b/lightkeeper.js
@@ -36,11 +36,11 @@ process.on('SIGINT', function() {
 program.description('Averages multiple successive Lighthouse tests').argument('<url>', 'The URL to test').option('-t, --times <count>', 'The number of tests to run', {
   default: 10
 // Map args and begin running
-}).option('-d, --desktop', 'Test only desktop').option('-m, --mobile ', 'Test only mobile').option('-b, --block <urls>', 'Comma seperated URLs to block, wildcards allowed').option('-s, --summary', 'Only show summary rows').action(function({
+}).option('-d, --desktop', 'Test only desktop').option('-m, --mobile ', 'Test only mobile').option('-b, --block <urls>', 'Comma seperated URLs to block, wildcards allowed').option('-s, --summary', 'Only show summary rows').action(async function({
     args: {url},
     options: {times, desktop, mobile, block, summary}
   }) {
-  var blockedUrls, devices;
+  var blockedUrls, devices, j, len, results1, urls;
   devices = (function() {
     switch (false) {
       case !mobile:
@@ -52,7 +52,23 @@ program.description('Averages multiple successive Lighthouse tests').argument('<
     }
   })();
   blockedUrls = block ? block.split(',') : [];
-  return execute({url, times, devices, blockedUrls, summary});
+  if ((url != null ? typeof url.indexOf === "function" ? url.indexOf(" ") : void 0 : void 0) > 0) {
+    // If url contains a space, assume space-separated URLs.  Split into array and test each url.
+    urls = typeof url.split === "function" ? url.split(" ") : void 0;
+    results1 = [];
+    for (j = 0, len = urls.length; j < len; j++) {
+      url = urls[j];
+      // Output this site's url
+      console.log("");
+      console.log(chalk.green.bold(url));
+      console.log("");
+      // Test this url
+      results1.push((await execute({url, times, devices, blockedUrls, summary})));
+    }
+    return results1;
+  } else {
+    return execute({url, times, devices, blockedUrls, summary});
+  }
 });
 
 program.run();

--- a/lightkeeper.js
+++ b/lightkeeper.js
@@ -33,7 +33,7 @@ process.on('SIGINT', function() {
 });
 
 // Setup CLI
-program.description('Averages multiple successive Lighthouse tests').argument('<url>', 'The URL to test').option('-t, --times <count>', 'The number of tests to run', {
+program.description('Averages multiple successive Lighthouse tests').argument('<url>', 'The comma-delimited URL(s) to test').option('-t, --times <count>', 'The number of tests to run', {
   default: 10
 // Map args and begin running
 }).option('-d, --desktop', 'Test only desktop').option('-m, --mobile ', 'Test only mobile').option('-b, --block <urls>', 'Comma seperated URLs to block, wildcards allowed').option('-s, --summary', 'Only show summary rows').action(async function({
@@ -52,25 +52,20 @@ program.description('Averages multiple successive Lighthouse tests').argument('<
     }
   })();
   blockedUrls = block ? block.split(',') : [];
-  if ((url != null ? typeof url.indexOf === "function" ? url.indexOf(" ") : void 0 : void 0) > 0) {
-    // If url contains a space, assume space-separated URLs.  Split into array and test each url.
-    urls = typeof url.split === "function" ? url.split(" ") : void 0;
-    results1 = [];
-    for (j = 0, len = urls.length; j < len; j++) {
-      url = urls[j];
-      // Output this site's url
-      console.log("");
-      console.log(chalk.green.bold(url));
-      console.log("");
-      // Test this url
-      results1.push((await execute({url, times, devices, blockedUrls, summary})));
-    }
-    return results1;
-  } else {
-    return execute({url, times, devices, blockedUrls, summary});
+  // If url contains a space, assume space-separated URLs.  Split into array and
+  // test each url.
+  urls = url.split(',');
+  results1 = [];
+  for (j = 0, len = urls.length; j < len; j++) {
+    url = urls[j];
+    console.log("");
+    console.log(chalk.yellow.bold(url));
+    results1.push((await execute({url, times, devices, blockedUrls, summary})));
   }
+  return results1;
 });
 
+// Start cli program
 program.run();
 
 // Boot up the runner


### PR DESCRIPTION
This adds support for testing multiple URLs using a space-separated string, like:

`lightkeeper "https://example.com/page1 https://example.com/page2"`

While also preserving the original syntax:

`lightkeeper https://example.com/page1`